### PR TITLE
Stylesheet rule insertion fix for modern browsers & responsive web sites

### DIFF
--- a/activity-indicator/activity-indicator.js
+++ b/activity-indicator/activity-indicator.js
@@ -147,7 +147,14 @@
 						rule += p1 + value + p2 + value; 
 					}
 					rule += '100% { -webkit-transform:rotate(100deg); }\n}';
-					document.styleSheets[0].insertRule(rule);
+					var sheet = (function() {
+						var style = document.createElement("style");
+						style.setAttribute("media", "screen")
+						style.appendChild(document.createTextNode(""));
+						document.head.appendChild(style);
+						return style.sheet;
+					})();
+					sheet.insertRule(rule, 0);
 					animations[steps] = name;
 				}
 				el.css('-webkit-animation', animations[steps] + ' ' + duration +'s linear infinite');


### PR DESCRIPTION
Critical update to work with modern browsers/responsive sites. 

Updated deprecated method for insertRule, which now requires two parameters.  Also corrected serious bug with blind insert into stylesheet[0] without regard for the media type/media query of the first stylesheet - which in many sites is no longer a generic screen type as it was 4-5 years ago when this was last updated.  Now the system creates a new stylesheet for rule insertion.
